### PR TITLE
feat: `block`…`end`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +221,7 @@ version = "0.1.0"
 dependencies = [
  "ariadne",
  "clap",
+ "derivative",
  "derive_more",
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 ariadne = "0.1.5"
 clap = { version = "4.1.6", features = ["derive"] }
+derivative = "2.2.0"
 derive_more = "0.99.17"
 env_logger = "0.10.0"
 log = "0.4.17"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -47,7 +47,7 @@ mod tests {
     }
 }
 
-#[derive(Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub enum Statement {
     /// <int_literal> <new_line>
     Print {
@@ -61,4 +61,7 @@ pub enum Statement {
         identifier: String,
         expression: Expression,
     },
+    Block {
+        inner_statements: Box<Vec<Self>>
+    }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,7 +6,7 @@ pub mod after_parse;
 
 /// 現時点のプログラムとは、プリントするべき式の列である
 #[allow(clippy::module_name_repetitions)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RootAst {
     pub(crate) statement: Vec<Statement>
 }

--- a/src/ast/after_parse.rs
+++ b/src/ast/after_parse.rs
@@ -1,6 +1,7 @@
 //! パース時の優先順位が消去された構造体の定義
 
 use derive_more::Display;
+use crate::ast::Statement;
 
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub enum Expression {
@@ -30,6 +31,10 @@ pub enum Expression {
         condition: Box<Self>,
         then_clause_value: Box<Self>,
         else_clause_value: Box<Self>,
+    },
+    Block {
+        intermediate_statements: Vec<Statement>,
+        final_expression: Box<Self>,
     }
 }
 

--- a/src/cli/task/interpret.rs
+++ b/src/cli/task/interpret.rs
@@ -1,7 +1,7 @@
 use crate::cli::task::print_ast::ParseSource;
 use crate::cli::task::Task;
 use crate::error::AllError;
-use crate::runtime::Runtime;
+use crate::runtime::{PrintToStdout, Runtime};
 use crate::type_check::TypeChecker;
 
 pub struct Interpret;
@@ -17,8 +17,8 @@ impl Task for Interpret {
         let root_ast = parser.parse()?;
         let type_checker = TypeChecker::new();
         type_checker.check(&root_ast)?;
-        let runtime = Runtime::create();
-        runtime.execute(&root_ast);
+        let runtime = Runtime::create(PrintToStdout);
+        runtime.execute(root_ast);
         Ok(())
     }
 }

--- a/src/cli/task/repl.rs
+++ b/src/cli/task/repl.rs
@@ -7,7 +7,7 @@ use crate::error::AllError;
 use crate::lexer::Token;
 use crate::platform::CTRL_D_NL;
 use crate::parser::{IntermediateStateCandidate, Parser, ParserError, PartiallyParseFixCandidate};
-use crate::runtime::{Runtime, TypeBox};
+use crate::runtime::{PrintToStdout, Runtime, TypeBox};
 use crate::type_check::TypeChecker;
 
 pub struct Repl;
@@ -18,7 +18,7 @@ impl Task for Repl {
 
     fn execute(&self, _environment: Self::Environment) -> Result<(), Self::Error> {
         let mut line_count = 1;
-        let runtime = Runtime::create();
+        let runtime = Runtime::create(PrintToStdout);
         println!("Welcome to REPL!");
         let checker = TypeChecker::new();
         loop {
@@ -38,7 +38,7 @@ impl Task for Repl {
             match parser.parse() {
                 Ok(ast) => {
                     checker.check(&ast)?;
-                    runtime.execute(&ast);
+                    runtime.execute(ast);
                 }
                 Err(error_message) => {
                     let error = error_message.kind;

--- a/src/cli/task/test.rs
+++ b/src/cli/task/test.rs
@@ -247,22 +247,19 @@ var a = 2
 print a
 end
 "#)?, type_boxes![2 => NonCoercedInteger]);
-        /*
         assert_eq!(Self::evaluated_expressions(r#"var a = 1
 var discard = block
 if true then block
 var a = 2
 print a
 ()
-end
-else block
+end else block
 var a = 3
 print a
 ()
 end
 end
 "#)?, type_boxes![2 => NonCoercedInteger]);
-         */
         Ok(())
     }
 

--- a/src/cli/task/test.rs
+++ b/src/cli/task/test.rs
@@ -252,7 +252,8 @@ block
 var a = 2
 print a
 end
-"#)?, type_boxes![2 => NonCoercedInteger]);
+print a
+"#)?, type_boxes![2 => NonCoercedInteger, 1 => NonCoercedInteger]);
         assert_eq!(Self::evaluated_expressions(r#"var a = 1
 var discard = block
 if true then block
@@ -266,6 +267,17 @@ print a
 end
 end
 "#)?, type_boxes![2 => NonCoercedInteger]);
+        assert_eq!(Self::evaluated_expressions(r#"var a = 1
+block
+    block
+        block
+            var a = 2
+            print a
+        end
+    end
+end
+"#)?, type_boxes![2 => NonCoercedInteger]);
+
         Ok(())
     }
 

--- a/src/cli/task/test.rs
+++ b/src/cli/task/test.rs
@@ -46,7 +46,7 @@ impl Test {
         let parser = Parser::create(source);
         let root_ast = parser.parse()?;
         let runtime = Runtime::create();
-        Ok(runtime.yield_all_evaluated_expressions(&root_ast))
+        Ok(runtime.eval(&root_ast))
     }
 
     #[allow(clippy::unreadable_literal)]
@@ -100,6 +100,7 @@ impl Test {
         Self::test_infix_op_does_not_cause_panic_by_arithmetic_overflow()?;
         Self::test_overflowed_literal()?;
         Self::test_variable_reassign()?;
+        Self::test_block_scope()?;
 
         Ok(())
     }
@@ -236,6 +237,32 @@ impl Test {
     fn test_variable_reassign() -> Result<(), SimpleErrorWithPos> {
         assert_eq!(Self::evaluated_expressions("var a = 1\na = 2\nprint a\n")?, type_boxes![2 => NonCoercedInteger]);
 
+        Ok(())
+    }
+
+    fn test_block_scope() -> Result<(), SimpleErrorWithPos> {
+        assert_eq!(Self::evaluated_expressions(r#"var a = 1
+block
+var a = 2
+print a
+end
+"#)?, type_boxes![2 => NonCoercedInteger]);
+        /*
+        assert_eq!(Self::evaluated_expressions(r#"var a = 1
+var discard = block
+if true then block
+var a = 2
+print a
+()
+end
+else block
+var a = 3
+print a
+()
+end
+end
+"#)?, type_boxes![2 => NonCoercedInteger]);
+         */
         Ok(())
     }
 

--- a/src/cli/task/test.rs
+++ b/src/cli/task/test.rs
@@ -1,10 +1,11 @@
 #![forbid(dead_code)]
 #![allow(clippy::unnecessary_wraps)]
 
+use std::borrow::Borrow;
 use log::debug;
 use crate::cli::task::Task;
 use crate::parser::{ParserError, SimpleErrorWithPos};
-use crate::runtime::{Runtime, TypeBox};
+use crate::runtime::{Runtime, TypeBox, Accumulate};
 
 type Err = SimpleErrorWithPos;
 
@@ -45,8 +46,13 @@ impl Test {
         let source = src;
         let parser = Parser::create(source);
         let root_ast = parser.parse()?;
-        let runtime = Runtime::create();
-        Ok(runtime.eval(&root_ast))
+        let acc = Accumulate::default();
+        let runtime = Runtime::create(acc);
+        let o = runtime.what_will_happen(root_ast.clone());
+        println!("{o:?}", o = &o);
+        let o = runtime.execute(root_ast);
+        let x = Ok(o.as_ref().borrow().acc().expect("???"));
+        x
     }
 
     #[allow(clippy::unreadable_literal)]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 use crate::ast::{SourcePos, WithPosition};
 use crate::char_list::{ASCII_LOWERS, ASCII_NUMERIC_CHARS};
 
-static KEYWORDS: [&str; 8] =
-    ["var", "if", "else", "then", "exit", "true", "false", "print"];
+static KEYWORDS: [&str; 10] =
+    ["var", "if", "else", "then", "exit", "true", "false", "print", "block", "end"];
 
 #[derive(Error, Debug, Eq, PartialEq)]
 #[allow(clippy::module_name_repetitions)]
@@ -198,6 +198,8 @@ impl Lexer {
                                     "then" => Token::KeywordThen,
                                     "else" => Token::KeywordElse,
                                     "print" => Token::KeywordPrint,
+                                    "block" => Token::KeywordBlock,
+                                    "end" => Token::KeywordEnd,
                                     other => Token::Reserved {
                                         matched: other.to_string(),
                                     }
@@ -366,7 +368,6 @@ impl Lexer {
         if advance_step == 0 {
             let token = self.next();
             self.set_current_index(to_rollback);
-            trace!("rollbacked");
             token
         } else {
             let mut token: Option<WithPosition<Token>> = None;
@@ -374,7 +375,6 @@ impl Lexer {
                 token = Some(self.next());
             }
             self.set_current_index(to_rollback);
-            trace!("rollbacked");
             // SAFETY: we already initialize it.
             unsafe { token.unwrap_unchecked() }
         }
@@ -410,6 +410,7 @@ impl Lexer {
     }
 
     fn advance(&self) {
+        trace!("lexer:advance");
         self.set_current_index(self.current_index.get() + 1);
     }
 }
@@ -436,6 +437,8 @@ pub enum Token {
     KeywordFalse,
     /// `print $expr`
     KeywordPrint,
+    KeywordBlock,
+    KeywordEnd,
     /// `"="`
     SymEq,
     /// `"+"`

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,12 @@ mod platform;
 fn main() -> Result<(), crate::error::AllError> {
     use crate::cli::args::Args;
     use clap::Parser;
-    // std::env::set_var("RUST_LOG", "trace");
+    std::env::set_var("RUST_LOG", "trace");
     ::env_logger::init();
     let args = Args::parse();
-    args.execute()?;
+    if let Err(e) = args.execute() {
+        log::error!("{e}", e = &e);
+        return Err(e)
+    }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ mod platform;
 fn main() -> Result<(), crate::error::AllError> {
     use crate::cli::args::Args;
     use clap::Parser;
-    std::env::set_var("RUST_LOG", "trace");
+    // std::env::set_var("RUST_LOG", "trace");
     ::env_logger::init();
     let args = Args::parse();
     if let Err(e) = args.execute() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -138,7 +138,7 @@ impl Parser {
         let head1 = self.lexer.peek();
         let head = head1.data;
         let pos = head1.position;
-        dbg!(&head);
+        // dbg!(&head);
         let s = match head {
             Token::Identifier { .. } => {
                 self.parse_variable_assignment()?
@@ -154,6 +154,9 @@ impl Parser {
                 (Statement::Print {
                     expression: expr
                 })
+            }
+            Token::KeywordBlock => {
+                self.parse_block_scope()?
             }
             x => return Err(SimpleErrorWithPos {
                 kind: ParserError::UnexpectedToken {
@@ -535,22 +538,22 @@ impl Parser {
 
     fn parse_lowest_precedence_expression(&self) -> Result<Expression, SimpleErrorWithPos> {
         debug!("expr:lowest");
-        self.parse_if_expression()
+        self.parse_block_expression()
     }
 
     fn parse_if_expression(&self) -> Result<Expression, SimpleErrorWithPos> {
         debug!("expr:if");
         if self.lexer.peek().data == Token::KeywordIf {
             self.lexer.next();
-            let condition = self.parse_if_expression()?;
+            let condition = self.parse_lowest_precedence_expression()?;
             let WithPosition { position, data } = self.lexer.peek();
             if data == Token::KeywordThen {
                 self.lexer.next();
-                let then_clause_value = self.parse_if_expression()?;
+                let then_clause_value = self.parse_lowest_precedence_expression()?;
                 let WithPosition { position, data } = self.lexer.peek();
                 if data == Token::KeywordElse {
                     self.lexer.next();
-                    let else_clause_value = self.parse_if_expression()?;
+                    let else_clause_value = self.parse_lowest_precedence_expression()?;
                     Ok(Expression::If {
                         condition: Box::new(condition),
                         then_clause_value: Box::new(then_clause_value),
@@ -570,6 +573,42 @@ impl Parser {
             }
         } else {
             self.parse_equality_expression()
+        }
+    }
+
+    fn parse_block_scope(&self) -> Result<Statement, SimpleErrorWithPos> {
+        debug!("parser:block:scope");
+        self.assert_token_eq_with_consumed(Token::KeywordBlock);
+        if self.lexer.peek().data == Token::NewLine {
+            self.lexer.next();
+        }
+
+        let mut statements = vec![];
+        while let Ok(v) = self.parse_statement() {
+            statements.push(v)
+        }
+        self.assert_token_eq_with_consumed(Token::KeywordEnd);
+        Ok(Statement::Block {
+            inner_statements: Box::new(statements),
+        })
+    }
+
+    fn parse_block_expression(&self) -> Result<Expression, SimpleErrorWithPos> {
+        debug!("parser:block:expr");
+        if self.lexer.peek().data == Token::KeywordBlock {
+            self.lexer.next();
+            self.assert_token_eq_with_consumed(Token::NewLine);
+            let mut statements = vec![];
+            while let Ok(v) = self.parse_statement() {
+                statements.push(v);
+            }
+            let final_expression = Box::new(self.parse_lowest_precedence_expression()?);
+            Ok(Expression::Block {
+                intermediate_statements: statements,
+                final_expression
+            })
+        } else {
+            self.parse_if_expression()
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -603,6 +603,10 @@ impl Parser {
                 statements.push(v);
             }
             let final_expression = Box::new(self.parse_lowest_precedence_expression()?);
+            if self.lexer.peek().data == Token::NewLine {
+                self.lexer.next();
+            }
+            self.assert_token_eq_with_consumed(Token::KeywordEnd);
             Ok(Expression::Block {
                 intermediate_statements: statements,
                 final_expression

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -349,7 +349,8 @@ impl CanBeEvaluated for &Expression {
             }
             Expression::Block { intermediate_statements, final_expression } => {
                 for s in intermediate_statements {
-                    runtime.execute1(s);
+                    let mut x = vec![];
+                    runtime.eval1(s, &mut x);
                 }
 
                 final_expression.as_ref().evaluate(runtime)

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -182,6 +182,9 @@ impl TypeCheckTarget for &Expression {
                     })
                 }
             }
+            Expression::Block { intermediate_statements, final_expression } => {
+                checker.check(final_expression.as_ref())
+            }
         }
     }
 }
@@ -210,6 +213,9 @@ impl TypeCheckTarget for &Statement {
                         actual_type,
                     })
                 }
+            }
+            Statement::Block { inner_statements: _ } => {
+                Ok(())
             }
         }
     }


### PR DESCRIPTION
* レキシカルスコープを持つ。
  * つまり、スコープから抜けたらスコープで確保した変数はなくなる
* ブロックの最後に何らかの式を記述するとブロック全体の評価結果としてその値を返す
* [x] 汎用性のためにif式にも使えるようにしたいがテストが動かない
* トップレベルでは、暗黙にその型がUnitとして評価される
  * 最後の式は評価された後にその結果が暗黙に捨てられる

close #82 