### PR TITLE
fix: Lexer::next() has reported wrong token position

### DIFF
--- a/package/origlang-compiler/src/lexer.rs
+++ b/package/origlang-compiler/src/lexer.rs
@@ -35,7 +35,6 @@ impl<T> AssociateWithPos for T {
     }
 }
 
-// FIXME: 行番号、列番号がおかしい
 #[derive(Debug)]
 pub struct Lexer {
     source_bytes_nth: Cell<Utf8CharBoundaryStartByte>,

--- a/package/origlang-compiler/src/lexer.rs
+++ b/package/origlang-compiler/src/lexer.rs
@@ -658,4 +658,3 @@ impl Lexer {
         TemporalLexerUnwindToken::new(self.source_bytes_nth.get())
     }
 }
-

--- a/package/origlang-compiler/src/lexer.rs
+++ b/package/origlang-compiler/src/lexer.rs
@@ -302,9 +302,13 @@ impl Lexer {
             return Token::EndOfFile.with_pos(self)
         }
 
-        let r = self.next_inner()
-            .expect("Lexer phase error")
-            .with_pos(self);
+        let pos = self.current_pos();
+
+        let r = WithPosition {
+            data: self.next_inner()
+                .expect("Lexer phase error"),
+            position: pos,
+        };
 
         debug!("next: {r:?}", r = &r);
         r

--- a/package/origlang-compiler/src/lexer/tests.rs
+++ b/package/origlang-compiler/src/lexer/tests.rs
@@ -103,3 +103,49 @@ fn avoid_off_read() {
         assert_eq!(lexer.consume_char().expect("oops"), S.chars().nth(i).expect("out of bounds from literal"))
     }
 }
+
+use std::num::NonZeroUsize;
+use origlang_source_span::{Pointed, SourcePosition};
+
+#[test]
+fn token_location() {
+    let src = "var x = 1\n";
+    let lexer = Lexer::create(src);
+
+    assert_eq!(lexer.next(), Pointed {
+        data: Token::VarKeyword,
+        position: SourcePosition {
+            line: NonZeroUsize::new(1).unwrap(),
+            column: NonZeroUsize::new(1).unwrap()
+        }
+    });
+
+    assert_eq!(lexer.next(), Pointed {
+        data: Token::Identifier {
+            inner: Identifier::new("x".to_string())
+        },
+        position: SourcePosition {
+            line: NonZeroUsize::new(1).unwrap(),
+            column: NonZeroUsize::new(5).unwrap()
+        }
+    });
+
+    assert_eq!(lexer.next(), Pointed {
+        data: Token::SymEq,
+        position: SourcePosition {
+            line: NonZeroUsize::new(1).unwrap(),
+            column: NonZeroUsize::new(7).unwrap()
+        }
+    });
+
+    assert_eq!(lexer.next(), Pointed {
+        data: Token::Digits {
+            sequence: "1".to_string(),
+            suffix: None,
+        },
+        position: SourcePosition {
+            line: NonZeroUsize::new(1).unwrap(),
+            column: NonZeroUsize::new(9).unwrap()
+        }
+    });
+}

--- a/package/origlang-compiler/src/lexer/tests.rs
+++ b/package/origlang-compiler/src/lexer/tests.rs
@@ -109,7 +109,8 @@ use origlang_source_span::{Pointed, SourcePosition};
 
 #[test]
 fn token_location() {
-    let src = "var x = 1\n";
+    // TODO: var y = 2 w/o new line -> unexpected panic (scan_digits_suffix_opt)
+    let src = "var x = 1\nvar y = 2\n";
     let lexer = Lexer::create(src);
 
     assert_eq!(lexer.next(), Pointed {
@@ -145,6 +146,51 @@ fn token_location() {
         },
         position: SourcePosition {
             line: NonZeroUsize::new(1).unwrap(),
+            column: NonZeroUsize::new(9).unwrap()
+        }
+    });
+
+    assert_eq!(lexer.next(), Pointed {
+        data: Token::NewLine,
+        position: SourcePosition {
+            line: NonZeroUsize::new(1).unwrap(),
+            column: NonZeroUsize::new(10).unwrap()
+        }
+    });
+
+    assert_eq!(lexer.next(), Pointed {
+        data: Token::VarKeyword,
+        position: SourcePosition {
+            line: NonZeroUsize::new(2).unwrap(),
+            column: NonZeroUsize::new(1).unwrap()
+        }
+    });
+
+    assert_eq!(lexer.next(), Pointed {
+        data: Token::Identifier {
+            inner: Identifier::new("y".to_string())
+        },
+        position: SourcePosition {
+            line: NonZeroUsize::new(2).unwrap(),
+            column: NonZeroUsize::new(5).unwrap()
+        }
+    });
+
+    assert_eq!(lexer.next(), Pointed {
+        data: Token::SymEq,
+        position: SourcePosition {
+            line: NonZeroUsize::new(2).unwrap(),
+            column: NonZeroUsize::new(7).unwrap()
+        }
+    });
+
+    assert_eq!(lexer.next(), Pointed {
+        data: Token::Digits {
+            sequence: "2".to_string(),
+            suffix: None,
+        },
+        position: SourcePosition {
+            line: NonZeroUsize::new(2).unwrap(),
             column: NonZeroUsize::new(9).unwrap()
         }
     });


### PR DESCRIPTION
close #261 