### PR TITLE
perf: avoid unnecessary clone

### DIFF
--- a/package/origlang-compiler/src/type_check.rs
+++ b/package/origlang-compiler/src/type_check.rs
@@ -253,7 +253,7 @@ fn handle_atomic_pattern(
             }])
         }
         AtomicPattern::Tuple(tp) => {
-            desugar(tp.into(), expr, checker)
+            desugar(Cow::Borrowed(tp), expr, checker)
         }
     }
 }

--- a/package/origlang-compiler/src/type_check.rs
+++ b/package/origlang-compiler/src/type_check.rs
@@ -300,8 +300,8 @@ fn desugar(
             desugar(outer_destruction, *final_expression, checker)
         }
         TypedExpression::Tuple { expressions } => {
-            let m = outer_destruction.iter().enumerate().map(|(i, element_binding)| {
-                handle_atomic_pattern(expressions[i].clone(), element_binding, checker)
+            let m = outer_destruction.iter().zip(expressions).enumerate().map(|(i, (element_binding, expression))| {
+                handle_atomic_pattern(expression, element_binding, checker)
             }).collect::<Vec<_>>();
 
             let mut k = vec![];

--- a/package/origlang-compiler/src/type_check.rs
+++ b/package/origlang-compiler/src/type_check.rs
@@ -269,7 +269,7 @@ fn desugar(
                     let tuple_element_types = tuple_element_types.0;
                     if outer_destruction.len() == tuple_element_types.len() {
                         desugar(outer_destruction, TypedExpression::Tuple {
-                            expressions: tuple_element_types.clone().into_iter().enumerate().map(|(i, _)| TypedExpression::ExtractTuple {
+                            expressions: tuple_element_types.iter().enumerate().map(|(i, _)| TypedExpression::ExtractTuple {
                                 expr: Box::new(
                                     TypedExpression::Variable { ident: ident.clone(), tp: Type::tuple(tuple_element_types.clone()) }
                                 ),
@@ -300,8 +300,8 @@ fn desugar(
             desugar(outer_destruction, *final_expression, checker)
         }
         TypedExpression::Tuple { expressions } => {
-            let m = outer_destruction.into_iter().enumerate().map(|(i, element_binding)| {
-                handle_atomic_pattern(expressions[i].clone(), &element_binding, checker)
+            let m = outer_destruction.iter().enumerate().map(|(i, element_binding)| {
+                handle_atomic_pattern(expressions[i].clone(), element_binding, checker)
             }).collect::<Vec<_>>();
 
             let mut k = vec![];

--- a/package/origlang-compiler/src/type_check.rs
+++ b/package/origlang-compiler/src/type_check.rs
@@ -1,5 +1,6 @@
 pub mod error;
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::hash_map::RandomState;
 use std::collections::{HashMap, VecDeque};
@@ -252,13 +253,13 @@ fn handle_atomic_pattern(
             }])
         }
         AtomicPattern::Tuple(tp) => {
-            desugar(tp.clone(), expr, checker)
+            desugar(tp.into(), expr, checker)
         }
     }
 }
 
 fn desugar(
-    outer_destruction: Vec<AtomicPattern>, rhs: TypedExpression, checker: &TypeChecker,
+    outer_destruction: Cow<'_, [AtomicPattern]>, rhs: TypedExpression, checker: &TypeChecker,
 ) -> Result<Vec<TypedStatement>, TypeCheckError> {
     debug!("check: {outer_destruction:?} = {rhs:?}");
 
@@ -279,7 +280,7 @@ fn desugar(
                     } else {
                         debug!("tuple arity mismatch");
                         Err(TypeCheckError::UnsatisfiablePattern {
-                            pattern: AtomicPattern::Tuple(outer_destruction),
+                            pattern: AtomicPattern::Tuple(outer_destruction.to_vec()),
                             expression: TypedExpression::Variable { ident, tp: Type::tuple(tuple_element_types.clone()) },
                             expr_type: Type::tuple(tuple_element_types.clone()),
                         })
@@ -288,7 +289,7 @@ fn desugar(
                 other => {
                     debug!("non-tuple expression");
                     Err(TypeCheckError::UnsatisfiablePattern {
-                        pattern: AtomicPattern::Tuple(outer_destruction),
+                        pattern: AtomicPattern::Tuple(outer_destruction.to_vec()),
                         expression: TypedExpression::Variable { ident, tp: other.clone() },
                         expr_type: other,
                     })
@@ -371,7 +372,7 @@ fn desugar(
         other => {
             debug!("unsupported expression");
             Err(TypeCheckError::UnsatisfiablePattern {
-                pattern: AtomicPattern::Tuple(outer_destruction),
+                pattern: AtomicPattern::Tuple(outer_destruction.to_vec()),
                 expr_type: other.actual_type(),
                 expression: other,
             })


### PR DESCRIPTION
address #280

## before

```
git -c advice.detachedHead=false checkout a8aeb89a8399acb5d7ced9a3d27cba1e87137445 && CARGO_PROFILE_RELEASE_DEBUG=true RUSTFLAGS="-Awarnings" cargo run -p origlang-cli --release -
- execute --input-file ./compile/positive/perf/nested_tuple_2_1000.origlang
HEAD is now at a8aeb89 Merge pull request #282 from KisaragiEffective/fix/testsuite/log-regression
    Finished release [optimized + debuginfo] target(s) in 0.02s
     Running `target/release/origlang-cli execute --input-file ./compile/positive/perf/nested_tuple_2_1000.origlang`
init: 46ns
source: 1.483764ms
parser.ctor: 3.162688ms
parser.parse: 1.234062656s
typeck.ctor: 1.234070976s
typeck.check: 10.915282914s
runtime.ctor: 10.915301411s
runtime.run: 10.955619282s
```

## after

```
git -c advice.detachedHead=false checkout 981b47f55401e4fc0bed7c130dfcea9a3ad705d0 && CARGO_PROFILE_RELEASE_DEBUG=true RUSTFLAGS="-Awarnings" cargo run -p origlang-cli --release -- execute --input-file ./compile/positive/perf/nested_tuple_2_1000.origlang
HEAD is now at 981b47f refactor: express intuition more explicitly
    Finished release [optimized + debuginfo] target(s) in 0.02s
     Running `target/release/origlang-cli execute --input-file ./compile/positive/perf/nested_tuple_2_1000.origlang`
init: 51ns
source: 1.448468ms
parser.ctor: 3.162982ms
parser.parse: 1.165646592s
typeck.ctor: 1.165660387s
typeck.check: 1.635197136s
runtime.ctor: 1.635209278s
runtime.run: 1.671664304s
```