### PR TITLE
refactor: use try_and_eat_str in next_inner to improve readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +905,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +978,7 @@ dependencies = [
  "origlang-platform",
  "origlang-source-span",
  "origlang-typesystem-model",
+ "radix_trie",
  "rand",
  "thiserror",
 ]
@@ -1163,6 +1179,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]

--- a/package/origlang-compiler/Cargo.toml
+++ b/package/origlang-compiler/Cargo.toml
@@ -16,6 +16,7 @@ origlang-source-span = { path = "../origlang-source-span" }
 origlang-diagnostics = { path = "../origlang-diagnostics" }
 origlang-ir = { path = "../origlang-ir" }
 origlang-ir-optimizer = { path = "../origlang-ir-optimizer" }
+radix_trie = "0.2.1"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["min_const_gen"] }


### PR DESCRIPTION
パフォーマンスがデグレなのでtrie木を使うとどのぐらい変わるのか調べる

`./compile/positive/perf/nested_tuple_2_1000.origlang`

base
```
init: 60ns
source: 3.139157ms
parser.ctor: 5.091929ms
parser.parse: 1.113346791s
typeck.ctor: 1.113359475s
typeck.check: 1.582066961s
runtime.ctor: 1.582083932s
runtime.run: 1.619714911s
```

current
```
init: 54ns
source: 3.096889ms
parser.ctor: 4.43932ms
parser.parse: 1.436369643s
typeck.ctor: 1.436379527s
typeck.check: 1.9083364s
runtime.ctor: 1.908353615s
runtime.run: 1.94959187s
```